### PR TITLE
Refine API. Now it allows users to pass arguments to requests.

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -17,6 +17,15 @@ _USERNAME = "usersp"
 _PASSWORD = "passsp"
 _TEST_WRITE = False
 
+# ## If a special network environment is met, please configure requests as you need.
+# ## Otherwise, just keep it empty.
+_KWARGS = {
+    'proxies': {
+        'http': 'http://xxx.xxx.xxx.xxx:xxxx',
+        'https': 'https://xxx.xxx.xxx.xxx:xxxx'
+    },
+    'cert': ('cert', 'key')
+}
 
 def migrate_rev2_to_papi(api):
     print(">>> new ranking_all(mode='daily', page=1, per_page=50)")
@@ -167,7 +176,7 @@ def refresh_token(api):
 
 
 def main():
-    api = PixivAPI()
+    api = PixivAPI(**_KWARGS)
     api.login(_USERNAME, _PASSWORD)
 
     # migrate_rev2_to_papi(api)

--- a/pixivpy3/api.py
+++ b/pixivpy3/api.py
@@ -11,6 +11,10 @@ class BasePixivAPI(object):
     user_id = 0
     refresh_token = None
 
+    def __init__(self, **requests_kwargs):
+        """initialize requests kwargs if need be"""
+        self.requests_kwargs = requests_kwargs
+
     def parse_json(self, json_str):
         """parse str into JsonDict"""
 
@@ -40,11 +44,11 @@ class BasePixivAPI(object):
 
         try:
             if (method == 'GET'):
-                return requests.get(url, params=params, headers=req_header)
+                return requests.get(url, params=params, headers=req_header, **self.requests_kwargs)
             elif (method == 'POST'):
-                return requests.post(url, params=params, data=data, headers=req_header)
+                return requests.post(url, params=params, data=data, headers=req_header, **self.requests_kwargs)
             elif (method == 'DELETE'):
-                return requests.delete(url, params=params, data=data, headers=req_header)
+                return requests.delete(url, params=params, data=data, headers=req_header, **requests_kwargs)
         except Exception as e:
             raise PixivError('requests %s %s error: %s' % (method, url, e))
 
@@ -102,6 +106,10 @@ class BasePixivAPI(object):
 
 # Public-API
 class PixivAPI(BasePixivAPI):
+
+    def __init__(self, **requests_kwargs):
+        """initialize requests kwargs if need be"""
+        super().__init__(**requests_kwargs)
 
     # Check auth and set BearerToken to headers
     def auth_requests_call(self, method, url, headers={}, params=None, data=None):


### PR DESCRIPTION
In order to allow users to solve their networking issues themselves, pixivpy should give an interface for configuring the requests freely.
In my case, I need to access pixiv via proxy, so it is necessary for users to configure requests for their special needs.

I added constructor in the API classes respectively. In my opinion, it is the best place for accepting kwargs.