### PR TITLE
Reedit the parameter in download

### DIFF
--- a/pixivpy3/api.py
+++ b/pixivpy3/api.py
@@ -101,13 +101,15 @@ class BasePixivAPI(object):
         # return auth/token response
         return token
 
-    def download(self, url, prefix='', path=None, replace=False, referer='https://app-api.pixiv.net/'):
+    def download(self, url, prefix='', path=os.path.curdir, replace=False, referer='https://app-api.pixiv.net/'):
         """Download image to file (use 6.0 app-api)"""
-        if (not path):
-            path = prefix + os.path.basename(url)
-        if (not os.path.exists(path)) or replace:
+
+        name = prefix + os.path.basename(url)
+
+        img_path = os.path.join(path, name)
+        if (not os.path.exists(img_path)) or replace:
             # Write stream to file
             response = self.requests_call('GET', url, headers={ 'Referer': referer }, stream=True)
-            with open(path, 'wb') as out_file:
+            with open(img_path, 'wb') as out_file:
                 shutil.copyfileobj(response.raw, out_file)
             del response


### PR DESCRIPTION
I think 'path' is the download directory, not the file name. The 'prefix' is the file name's prefix. I can't use the 'path' to set download directory for many download images. So I think the previous method is not rational.

If I want download many img to a directory.
``` Python
# Before
for url in url_list:
    api.download(url.large, prefix='/home/ubuntu/Picture/')
# Now
for url in url_list:
    api.download(url.large, path='/home/ubuntu/Picture', prefix='Painter-')
```