### PR TITLE
use Android app ID to fix refresh_token

### DIFF
--- a/pixivpy3/api.py
+++ b/pixivpy3/api.py
@@ -10,8 +10,8 @@ from .utils import PixivError, JsonDict
 
 
 class BasePixivAPI(object):
-    client_id = 'bYGKuGVw91e0NMfPGp44euvGt59s'
-    client_secret = 'HP3RmkgAmEGro0gn1x9ioawQE8WMfvLXDz3ZqxpK'
+    client_id = 'MOBrBDS8blbauoSck0ZfDbtuzpyT'
+    client_secret = 'lsACyCD94FhDUtGTXi3QzcFE2uU1hqtDaKeqrdwj'
 
     access_token = None
     user_id = 0
@@ -63,10 +63,7 @@ class BasePixivAPI(object):
 
         url = 'https://oauth.secure.pixiv.net/auth/token'
         headers = {
-            'App-OS': 'ios',
-            'App-OS-Version': '10.3.1',
-            'App-Version': '6.7.1',
-            'User-Agent': 'PixivIOSApp/6.7.1 (iOS 10.3.1; iPhone8,1)',
+            'User-Agent': 'PixivAndroidApp/5.0.64 (Android 6.0)',
         }
         data = {
             'get_secure_url': 1,


### PR DESCRIPTION
Extracted from the apk. With this ID, refresh_token works correctly (see #12).

(I don't think the User-Agent header matters, pixiv doesn't seem to check it, but I updated it anyway.)