### PR TITLE
Expose `include_sanity_level` for works() function.

### DIFF
--- a/pixivpy3/papi.py
+++ b/pixivpy3/papi.py
@@ -38,11 +38,12 @@ class PixivAPI(BasePixivAPI):
         return self.parse_result(r)
 
     # 作品详细
-    def works(self, illust_id):
-        url = 'https://public-api.secure.pixiv.net/v1/works/%d.json' % (illust_id)
+    def works(self, illust_id, include_sanity_level=False):
+        url = f'https://public-api.secure.pixiv.net/v1/works/%d.json' % (illust_id)
         params = {
             'image_sizes': 'px_128x128,small,medium,large,px_480mw',
             'include_stats': 'true',
+            'include_sanity_level': str(include_sanity_level).lower()
         }
         r = self.auth_requests_call('GET', url, params=params)
         return self.parse_result(r)

--- a/pixivpy3/papi.py
+++ b/pixivpy3/papi.py
@@ -39,7 +39,7 @@ class PixivAPI(BasePixivAPI):
 
     # 作品详细
     def works(self, illust_id, include_sanity_level=False):
-        url = f'https://public-api.secure.pixiv.net/v1/works/%d.json' % (illust_id)
+        url = 'https://public-api.secure.pixiv.net/v1/works/%d.json' % (illust_id)
         params = {
             'image_sizes': 'px_128x128,small,medium,large,px_480mw',
             'include_stats': 'true',


### PR DESCRIPTION
When "include_sanity_level" is true, `sanity_level` becomes available.
```
'black': Example: <illust_id=55633043> |  
> "Not Safe For Work. Not Available to accounts that are not signed up"  

'semi-black': Example <illust_id=???> |
> "Not Really Safe For Work. Also Known as Suspicious for other booru websites. Not 
   available to accounts that are not signed up [Confirmation needed]"  

'white': Example <illust_id=30090738> |
> "Generally Safe For Work. Available to everyone."  
```
