### PR TITLE
Set headers method + tag translations example

### DIFF
--- a/example_tag_translations.py
+++ b/example_tag_translations.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import sys
+if sys.version_info >= (3, 0):
+    import imp
+    imp.reload(sys)
+else:
+    reload(sys)
+    sys.setdefaultencoding('utf8')
+sys.dont_write_bytecode = True
+
+from pixivpy3 import *
+from datetime import *
+
+# change _USERNAME,_PASSWORD first!
+_USERNAME = "userbay"
+_PASSWORD = "userpay"
+
+
+def main():
+    aapi = AppPixivAPI()
+    aapi.set_additional_headers({'Accept-Language':'en-US'})
+    aapi.login(_USERNAME, _PASSWORD)
+    json_result = aapi.illust_ranking('day', date=(datetime.now() - timedelta(days=5)).strftime('%Y-%m-%d'))
+
+    print("Printing image titles and tags with English tag translations present when available")
+
+    for illust in json_result.illusts[:3]:
+        print("Illustration: \"" + str(illust.title) + "\"\nTags: " + str(illust.tags) + "\n")
+
+
+
+
+if __name__ == '__main__':
+    main()
+

--- a/pixivpy3/api.py
+++ b/pixivpy3/api.py
@@ -21,6 +21,11 @@ class BasePixivAPI(object):
         """initialize requests kwargs if need be"""
         self.requests = requests.Session()
         self.requests_kwargs = requests_kwargs
+        self.additional_headers = {}
+
+    def set_additional_headers(self, headers):
+        """manually specify additional headers. will overwrite API default headers in case of collision"""
+        self.additional_headers = headers
 
     def parse_json(self, json_str):
         """parse str into JsonDict"""
@@ -40,6 +45,7 @@ class BasePixivAPI(object):
 
     def requests_call(self, method, url, headers={}, params=None, data=None, stream=False):
         """ requests http/https call for Pixiv API """
+        headers.update(self.additional_headers)
         try:
             if (method == 'GET'):
                 return self.requests.get(url, params=params, headers=headers, stream=stream, **self.requests_kwargs)


### PR DESCRIPTION
Added a method for setting additional headers on the API object, as well as an example of how setting language headers can be used to get tag translations. Modeled the example after other examples.

PR to resolve issue #76 . 