### PR TITLE
Add pathlike support for download path

### DIFF
--- a/pixivpy3/api.py
+++ b/pixivpy3/api.py
@@ -4,6 +4,7 @@ import json
 import os
 import shutil
 from datetime import datetime
+from pathlib import Path
 
 import requests
 
@@ -132,19 +133,21 @@ class BasePixivAPI(object):
         # return auth/token response
         return token
 
-    def download(self, url, prefix='', path=os.path.curdir, name=None, replace=False,
+    def download(self, url, prefix='', path=None, name=None, replace=False,
                  referer='https://app-api.pixiv.net/'):
         """Download image to file (use 6.0 app-api)"""
+        path = Path(path or '')
+
         if not name:
             name = prefix + os.path.basename(url)
         else:
             name = prefix + name
 
-        img_path = os.path.join(path, name)
-        if (not os.path.exists(img_path)) or replace:
+        img_path = path / name
+        if not img_path.is_file() or replace:
             # Write stream to file
             response = self.requests_call('GET', url, headers={'Referer': referer}, stream=True)
-            with open(img_path, 'wb') as out_file:
+            with img_path.open('wb') as out_file:
                 shutil.copyfileobj(response.raw, out_file)
             del response
             return True


### PR DESCRIPTION
Using `pathlib.Path` is often more convenient than using strings. You could eg. use it like this:
```python
...
imaage_path = Path('foo/bar/image.jpg')
api.download(url='some_url', path=image_path.parent, name=image_path.name)
...
# Do other stuff with image_path
```