### PR TITLE
introduce 'user_related' for searching for users similiar to given ID

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -112,6 +112,11 @@ def appapi_users(aapi):
     json_result = aapi.user_mypixiv(275527)
     print(json_result)
 
+    json_result = aapi.user_related(275527)
+    # print(json_result)
+    users = [x["id"] for x in json_result.user_previews]
+    print(">>> user IDs: %s", users)
+
 
 def appapi_search(aapi):
     first_tag = None

--- a/pixivpy3/aapi.py
+++ b/pixivpy3/aapi.py
@@ -147,16 +147,6 @@ class AppPixivAPI(BasePixivAPI):
         r = self.no_auth_requests_call('GET', url, params=params, req_auth=req_auth)
         return self.parse_result(r)
 
-    def user_related(self, seed_user_id, filter="for_ios", offset=None, req_auth=True):
-        url = '%s/v1/user/related' % self.hosts
-        params = {
-            'filter': filter,
-            'offset': offset if offset else 0,  # Pixiv warns to put seed_user_id at the end -> put offset here
-            'seed_user_id': seed_user_id
-        }
-        r = self.no_auth_requests_call('GET', url, params=params, req_auth=req_auth)
-        return self.parse_result(r)
-
     # 关注用户的新作
     # restrict: [public, private]
     def illust_follow(self, restrict='public', offset=None, req_auth=True):

--- a/pixivpy3/aapi.py
+++ b/pixivpy3/aapi.py
@@ -137,6 +137,26 @@ class AppPixivAPI(BasePixivAPI):
         r = self.no_auth_requests_call('GET', url, params=params, req_auth=req_auth)
         return self.parse_result(r)
 
+    def user_related(self, seed_user_id, filter="for_ios", offset=None, req_auth=True):
+        url = '%s/v1/user/related' % self.hosts
+        params = {
+            'filter': filter,
+            'offset': offset if offset else 0,  # Pixiv warns to put seed_user_id at the end -> put offset here
+            'seed_user_id': seed_user_id
+        }
+        r = self.no_auth_requests_call('GET', url, params=params, req_auth=req_auth)
+        return self.parse_result(r)
+
+    def user_related(self, seed_user_id, filter="for_ios", offset=None, req_auth=True):
+        url = '%s/v1/user/related' % self.hosts
+        params = {
+            'filter': filter,
+            'offset': offset if offset else 0,  # Pixiv warns to put seed_user_id at the end -> put offset here
+            'seed_user_id': seed_user_id
+        }
+        r = self.no_auth_requests_call('GET', url, params=params, req_auth=req_auth)
+        return self.parse_result(r)
+
     # 关注用户的新作
     # restrict: [public, private]
     def illust_follow(self, restrict='public', offset=None, req_auth=True):


### PR DESCRIPTION
I've coincidently found that using a URL similar to the one used for fetching related illustrations also works for fetching related users. I can't guaranty that I didn't miss any arguments that can be used. 
Also, its worth noting that, although pagination is possible (offset can be used, responses are limited to 30 users), there is no next_url argument in the response. It should be possible to inject one though. 