### PR TITLE
fix: add more CF-DNS-Query URLs

### DIFF
--- a/pixivpy3/bapi.py
+++ b/pixivpy3/bapi.py
@@ -7,34 +7,38 @@ from .aapi import AppPixivAPI
 
 
 class ByPassSniApi(AppPixivAPI):
-
     def __init__(self, **requests_kwargs):
         """initialize requests kwargs if need be"""
         super(AppPixivAPI, self).__init__(**requests_kwargs)
         session = requests.Session()
-        session.mount('https://', host_header_ssl.HostHeaderSSLAdapter())
+        session.mount("https://", host_header_ssl.HostHeaderSSLAdapter())
         self.requests = session
 
-    def require_appapi_hosts(self, hostname='app-api.pixiv.net', timeout=3):
+    def require_appapi_hosts(self, hostname="app-api.pixiv.net", timeout=3):
         """
-        通过cloudflare的 DNS over HTTPS 请求真实的ip地址
+        通过 Cloudflare 的 DNS over HTTPS 请求真实的 IP 地址。
         """
-        url = 'https://1.0.0.1/dns-query'   # 先使用1.0.0.1的地址
+        URLS = (
+            "https://1.0.0.1/dns-query",
+            "https://1.1.1.1/dns-query",
+            "https://[2606:4700:4700::1001]/dns-query",
+            "https://[2606:4700:4700::1111]/dns-query",
+            "https://cloudflare-dns.com/dns-query",
+        )
         params = {
-            'ct': 'application/dns-json',
-            'name': hostname,
-            'type': 'A',
-            'do': 'false',
-            'cd': 'false',
+            "ct": "application/dns-json",
+            "name": hostname,
+            "type": "A",
+            "do": "false",
+            "cd": "false",
         }
 
-        try:
-            response = requests.get(url, params=params, timeout=timeout)
-        except Exception:
-            # 根据 #111 的反馈，部分地区无法访问1.0.0.1，此时尝试域名解析
-            url = 'https://cloudflare-dns.com/dns-query'
-            response = requests.get(url, params=params, timeout=timeout)
+        for url in URLS:
+            try:
+                response = requests.get(url, params=params, timeout=timeout)
+                self.hosts = "https://" + response.json()["Answer"][0]["data"]
+                return self.hosts
+            except Exception:
+                pass
 
-        # 返回第一个解析到的IP
-        self.hosts = 'https://' + response.json()['Answer'][0]['data']
-        return self.hosts
+        return False


### PR DESCRIPTION
#### Add more Cloudflare DNS-Query URLs
Since the original code only tries **1.0.0.1** and **cloudflare-dns.com**, some ISPs in parts of China still can't connect properly.

Therefore, I tried to use more Cloudflare DNS-Query URLs, and the situation improved a lot. All URLs are as follows:

- https://1.0.0.1/dns-query
- https://1.1.1.1/dns-query
- https://[2606:4700:4700::1001]/dns-query
- https://[2606:4700:4700::1111]/dns-query
- https://cloudflare-dns.com/dns-query

#### Fix possible dictionary indexing error
In the original code, there are possible problems with the direct assignment behavior (`self.hosts = 'https://' + response.json()['Answer'][0]['data']`). I have encountered  that `Answer` is not present in the returned results for several times.

I think it would be more strict to put it into `try:`.

#### Change the return content
If the request is correct, the real IP is returned. If all requests are incorrect, False is returned, which makes it easier for the programs to determine.

#### Reference
- https://wiki.archlinux.org/title/Cloudflared#Configuration
- https://developers.cloudflare.com/1.1.1.1/setting-up-1.1.1.1/router