### PR TITLE
fix: stubgen error

### DIFF
--- a/pixivpy3/aapi.py
+++ b/pixivpy3/aapi.py
@@ -111,7 +111,7 @@ class AppPixivAPI(BasePixivAPI):
         return self.parse_result(r)
 
     # 用户作品列表
-    # type: [illust, manga]
+    # content_type: [illust, manga]
     def user_illusts(self, user_id, type='illust', filter='for_ios', offset=None, req_auth=True):
         url = '%s/v1/user/illusts' % self.hosts
         params = {

--- a/pixivpy3/aapi.py
+++ b/pixivpy3/aapi.py
@@ -111,7 +111,7 @@ class AppPixivAPI(BasePixivAPI):
         return self.parse_result(r)
 
     # 用户作品列表
-    # content_type: [illust, manga]
+    ## type: [illust, manga]
     def user_illusts(self, user_id, type='illust', filter='for_ios', offset=None, req_auth=True):
         url = '%s/v1/user/illusts' % self.hosts
         params = {


### PR DESCRIPTION
I fixed an error when creating mypy stubs using `stubgen`.

## Process

I tried to generate stub files and got error below .

```bash
$ git clone https://github.com/upbit/pixivpy
$ cd pixivpy
$ stubgen -p pixivpy3
Critical error during semantic analysis: pixivpy3/aapi.py:114: error: invalid syntax
```

https://github.com/upbit/pixivpy/blob/c133cb0302fbbe0601ec6529df6695ef7cb2d341/pixivpy3/aapi.py#L113-L115

`# type: [illust, manga]` was recognized by `mypy` as a type annotation for `def user_illusts(...):`

So I do: `sed -i '114s/type:/content_&/' pixivpy3/aapi.py`

Then I ran `stubgen` again and worked well.

```bash
$ stubgen -p pixivpy3
Processed 6 modules
Generated files under out/pixivpy3/
```