### PR TITLE
fix: use `max_illust_id` in `illust_new()` parameters

### DIFF
--- a/pixivpy3/aapi.py
+++ b/pixivpy3/aapi.py
@@ -508,13 +508,15 @@ class AppPixivAPI(BasePixivAPI):
         return self.parse_result(r)
 
     # 大家的新作
-    ## content_type: [illust, manga]
+    # content_type: [illust, manga]
     def illust_new(self, content_type="illust", filter='for_ios', max_illust_id=None, req_auth=True):
         url = '%s/v1/illust/new' % self.hosts
         params = {
             'content_type': content_type,
             'filter': filter,
         }
+        if max_illust_id:
+            params['max_illust_id'] = max_illust_id
         r = self.no_auth_requests_call('GET', url, params=params, req_auth=req_auth)
         return self.parse_result(r)
 


### PR DESCRIPTION
Fix for `illust_new` cannot retrieve more results. As @potpotkettle [suggested](https://github.com/upbit/pixivpy/commit/024d4e7212582ca6f31ef5592b4b5b46cb351cbc#commitcomment-60727126).