### PR TITLE
Limit required python version and remove codes for python<=3.5

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.5', '3.10']
+        python-version: ['3.6', '3.10']
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: ['3.5', '3.10']
 
     steps:
     - uses: actions/checkout@v1

--- a/demo.py
+++ b/demo.py
@@ -1,15 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import imp
 import sys
-from pixivpy3 import *
 
-if sys.version_info >= (3, 0):
-    import imp
-    imp.reload(sys)
-else:
-    reload(sys)
-    sys.setdefaultencoding('utf8')
+from pixivpy3 import AppPixivAPI
+
+imp.reload(sys)
+
 sys.dont_write_bytecode = True
 
 
@@ -34,7 +32,7 @@ def appapi_illust(aapi):
     json_result = aapi.illust_detail(59580629)
     print(json_result)
     illust = json_result.illust
-    print(">>> %s, origin url: %s" % (illust.title, illust.image_urls['large']))
+    print(">>> %s, origin url: %s" % (illust.title, illust.image_urls["large"]))
 
     json_result = aapi.illust_comments(59580629)
     print(json_result)
@@ -50,7 +48,7 @@ def appapi_recommend(aapi):
     json_result = aapi.illust_recommended(bookmark_illust_ids=[59580629])
     print(json_result)
     illust = json_result.illusts[0]
-    print(">>> %s, origin url: %s" % (illust.title, illust.image_urls['large']))
+    print(">>> %s, origin url: %s" % (illust.title, illust.image_urls["large"]))
 
     # get next page
     next_qs = aapi.parse_qs(json_result.next_url)
@@ -58,12 +56,12 @@ def appapi_recommend(aapi):
         json_result = aapi.illust_recommended(**next_qs)
         # print(json_result)
         illust = json_result.illusts[0]
-        print("  > %s, origin url: %s" % (illust.title, illust.image_urls['large']))
+        print("  > %s, origin url: %s" % (illust.title, illust.image_urls["large"]))
 
     json_result = aapi.illust_related(59580629)
     print(json_result)
     illust = json_result.illusts[0]
-    print(">>> %s, origin url: %s" % (illust.title, illust.image_urls['large']))
+    print(">>> %s, origin url: %s" % (illust.title, illust.image_urls["large"]))
 
     # get next page
     next_qs = aapi.parse_qs(json_result.next_url)
@@ -71,7 +69,7 @@ def appapi_recommend(aapi):
         json_result = aapi.illust_related(**next_qs)
         # print(json_result)
         illust = json_result.illusts[0]
-        print("  > %s, origin url: %s" % (illust.title, illust.image_urls['large']))
+        print("  > %s, origin url: %s" % (illust.title, illust.image_urls["large"]))
 
 
 def appapi_users(aapi):
@@ -83,7 +81,7 @@ def appapi_users(aapi):
     json_result = aapi.user_illusts(275527)
     print(json_result)
     illust = json_result.illusts[0]
-    print(">>> %s, origin url: %s" % (illust.title, illust.image_urls['large']))
+    print(">>> %s, origin url: %s" % (illust.title, illust.image_urls["large"]))
 
     # get next page
     next_qs = aapi.parse_qs(json_result.next_url)
@@ -91,12 +89,12 @@ def appapi_users(aapi):
         json_result = aapi.user_illusts(**next_qs)
         # print(json_result)
         illust = json_result.illusts[0]
-        print("  > %s, origin url: %s" % (illust.title, illust.image_urls['large']))
+        print("  > %s, origin url: %s" % (illust.title, illust.image_urls["large"]))
 
     json_result = aapi.user_bookmarks_illust(2088434)
     print(json_result)
     illust = json_result.illusts[0]
-    print(">>> %s, origin url: %s" % (illust.title, illust.image_urls['large']))
+    print(">>> %s, origin url: %s" % (illust.title, illust.image_urls["large"]))
 
     json_result = aapi.user_following(7314824)
     print(json_result)
@@ -126,12 +124,15 @@ def appapi_search(aapi):
     for trend_tag in response.trend_tags[:10]:
         if not first_tag:
             first_tag = trend_tag.tag
-        print("%s -  %s(id=%s)" % (trend_tag.tag, trend_tag.illust.title, trend_tag.illust.id))
+        print(
+            "%s -  %s(id=%s)"
+            % (trend_tag.tag, trend_tag.illust.title, trend_tag.illust.id)
+        )
 
-    json_result = aapi.search_illust(first_tag, search_target='partial_match_for_tags')
+    json_result = aapi.search_illust(first_tag, search_target="partial_match_for_tags")
     print(json_result)
     illust = json_result.illusts[0]
-    print(">>> %s, origin url: %s" % (illust.title, illust.image_urls['large']))
+    print(">>> %s, origin url: %s" % (illust.title, illust.image_urls["large"]))
 
     # get next page
     next_qs = aapi.parse_qs(json_result.next_url)
@@ -139,13 +140,13 @@ def appapi_search(aapi):
         json_result = aapi.search_illust(**next_qs)
         # print(json_result)
         illust = json_result.illusts[0]
-        print(">>> %s, origin url: %s" % (illust.title, illust.image_urls['large']))
+        print(">>> %s, origin url: %s" % (illust.title, illust.image_urls["large"]))
 
     # novel
-    json_result = aapi.search_novel('FGO', search_target='keyword')
+    json_result = aapi.search_novel("FGO", search_target="keyword")
     print(json_result)
     novel = json_result.novels[0]
-    print(">>> %s, origin url: %s" % (novel.title, novel.image_urls['large']))
+    print(">>> %s, origin url: %s" % (novel.title, novel.image_urls["large"]))
 
     # get next page
     next_qs = aapi.parse_qs(json_result.next_url)
@@ -153,18 +154,18 @@ def appapi_search(aapi):
         json_result = aapi.search_novel(**next_qs)
         # print(json_result)
         novel = json_result.novels[0]
-        print(">>> %s, origin url: %s" % (novel.title, novel.image_urls['large']))
+        print(">>> %s, origin url: %s" % (novel.title, novel.image_urls["large"]))
 
 
 def appapi_user_search(aapi):
-    json_result = aapi.illust_ranking('day_male')
+    json_result = aapi.illust_ranking("day_male")
     name = json_result.illusts[0].user.name
     print(">>> %s" % name)
 
     json_result = aapi.search_user(name)
     print(json_result)
     illust = json_result.user_previews[0].illusts[0]
-    print(">>> %s, origin url: %s" % (illust.title, illust.image_urls['large']))
+    print(">>> %s, origin url: %s" % (illust.title, illust.image_urls["large"]))
 
     # get next page
     next_qs = aapi.parse_qs(json_result.next_url)
@@ -172,14 +173,14 @@ def appapi_user_search(aapi):
         json_result = aapi.search_user(**next_qs)
         # print(json_result)
         illust = json_result.user_previews[0].illusts[0]
-        print(">>> %s, origin url: %s" % (illust.title, illust.image_urls['large']))
+        print(">>> %s, origin url: %s" % (illust.title, illust.image_urls["large"]))
 
 
 def appapi_ranking(aapi):
-    json_result = aapi.illust_ranking('day_male')
+    json_result = aapi.illust_ranking("day_male")
     print(json_result)
     illust = json_result.illusts[0]
-    print(">>> %s, origin url: %s" % (illust.title, illust.image_urls['large']))
+    print(">>> %s, origin url: %s" % (illust.title, illust.image_urls["large"]))
 
     # get next page
     next_qs = aapi.parse_qs(json_result.next_url)
@@ -187,20 +188,20 @@ def appapi_ranking(aapi):
         json_result = aapi.illust_ranking(**next_qs)
         # print(json_result)
         illust = json_result.illusts[0]
-        print(">>> %s, origin url: %s" % (illust.title, illust.image_urls['large']))
+        print(">>> %s, origin url: %s" % (illust.title, illust.image_urls["large"]))
 
     # 2016-07-15 日的过去一周排行
-    json_result = aapi.illust_ranking('week', date='2016-07-15')
+    json_result = aapi.illust_ranking("week", date="2016-07-15")
     print(json_result)
     illust = json_result.illusts[0]
-    print(">>> %s, origin url: %s" % (illust.title, illust.image_urls['large']))
+    print(">>> %s, origin url: %s" % (illust.title, illust.image_urls["large"]))
 
 
 def appapi_auth_api(aapi):
     json_result = aapi.illust_follow(req_auth=True)
     print(json_result)
     illust = json_result.illusts[0]
-    print(">>> %s, origin url: %s" % (illust.title, illust.image_urls['large']))
+    print(">>> %s, origin url: %s" % (illust.title, illust.image_urls["large"]))
 
     # get next page
     next_qs = aapi.parse_qs(json_result.next_url)
@@ -208,54 +209,74 @@ def appapi_auth_api(aapi):
         json_result = aapi.illust_follow(req_auth=True, **next_qs)
         # print(json_result)
         illust = json_result.illusts[0]
-        print(">>> %s, origin url: %s" % (illust.title, illust.image_urls['large']))
+        print(">>> %s, origin url: %s" % (illust.title, illust.image_urls["large"]))
 
     json_result = aapi.illust_recommended(req_auth=True)
     print(json_result)
     illust = json_result.illusts[0]
-    print(">>> %s, origin url: %s" % (illust.title, illust.image_urls['large']))
+    print(">>> %s, origin url: %s" % (illust.title, illust.image_urls["large"]))
 
 
 def appapi_bookmark_add(aapi):
     illust_id = 74187223
-    tags = ['Fate/GO', '50000users入り', '私服']
+    tags = ["Fate/GO", "50000users入り", "私服"]
     json_result = aapi.illust_bookmark_add(illust_id, tags=tags)
     json_result = aapi.illust_bookmark_detail(illust_id)
     print(json_result.bookmark_detail)
-    print(">>> %s, tags added: %s" %
-          (illust_id, [tag.name for tag in json_result.bookmark_detail.tags if tag.is_registered]))
+    print(
+        ">>> %s, tags added: %s"
+        % (
+            illust_id,
+            [tag.name for tag in json_result.bookmark_detail.tags if tag.is_registered],
+        )
+    )
 
 
 def appapi_novel(aapi):
     json_result = aapi.user_novels(59216290)
     print(json_result)
     novel = json_result.novels[0]
-    print(">>> %s, text_length: %s, series: %s" % (novel.title, novel.text_length, novel.series))
+    print(
+        ">>> %s, text_length: %s, series: %s"
+        % (novel.title, novel.text_length, novel.series)
+    )
 
     # get next page
     next_qs = aapi.parse_qs(json_result.next_url)
     if next_qs is not None:
         json_result = aapi.user_novels(**next_qs)
         novel = json_result.novels[0]
-        print(">>> %s, text_length: %s, series: %s" % (novel.title, novel.text_length, novel.series))
+        print(
+            ">>> %s, text_length: %s, series: %s"
+            % (novel.title, novel.text_length, novel.series)
+        )
 
     json_result = aapi.novel_series(1276963)
     print(json_result)
     detail = json_result.novel_series_detail
-    print(">>> %s, total_character_count: %s" % (detail.title, detail.total_character_count))
+    print(
+        ">>> %s, total_character_count: %s"
+        % (detail.title, detail.total_character_count)
+    )
 
     # get next page
     next_qs = aapi.parse_qs(json_result.next_url)
     if next_qs is not None:
         json_result = aapi.novel_series(**next_qs)
         detail = json_result.novel_series_detail
-        print(">>> %s, total_character_count: %s" % (detail.title, detail.total_character_count))
+        print(
+            ">>> %s, total_character_count: %s"
+            % (detail.title, detail.total_character_count)
+        )
 
     novel_id = 14357107
     json_result = aapi.novel_detail(novel_id)
     print(json_result)
     novel = json_result.novel
-    print(">>> %s, text_length: %s, series: %s" % (novel.title, novel.text_length, novel.series))
+    print(
+        ">>> %s, text_length: %s, series: %s"
+        % (novel.title, novel.text_length, novel.series)
+    )
 
     json_result = aapi.novel_text(novel_id)
     print(json_result)
@@ -280,5 +301,5 @@ def main():
     appapi_auth_api(aapi)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/download_illusts.py
+++ b/download_illusts.py
@@ -1,16 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from pixivpy3 import *
+import imp
 import os
 import sys
 
-if sys.version_info >= (3, 0):
-    import imp
-    imp.reload(sys)
-else:
-    reload(sys)
-    sys.setdefaultencoding('utf8')
+from pixivpy3 import AppPixivAPI, ByPassSniApi
+
+imp.reload(sys)
 sys.dont_write_bytecode = True
 
 
@@ -29,7 +26,7 @@ def main():
     api.auth(refresh_token=_REFRESH_TOKEN)
 
     # get rankings
-    json_result = api.illust_ranking('day', date='2019-01-01')
+    json_result = api.illust_ranking("day", date="2019-01-01")
 
     directory = "illusts"
     if not os.path.exists(directory):
@@ -37,7 +34,9 @@ def main():
 
     # download top3 day rankings to 'illusts' dir
     for idx, illust in enumerate(json_result.illusts[:4]):
-        image_url = illust.meta_single_page.get('original_image_url', illust.image_urls.large)
+        image_url = illust.meta_single_page.get(
+            "original_image_url", illust.image_urls.large
+        )
         print("%s: %s" % (illust.title, image_url))
 
         # try four args in MR#102
@@ -49,11 +48,15 @@ def main():
             name = "illust_id_%d_%s%s" % (illust.id, illust.title, extension)
             api.download(image_url, path=directory, name=name)
         elif idx == 2:
-            api.download(image_url, path=directory, fname='illust_%s.jpg' % (illust.id))
+            api.download(image_url, path=directory, fname="illust_%s.jpg" % (illust.id))
         else:
             # path will not work due to fname is a handler
-            api.download(image_url, path='/foo/bar', fname=open('%s/illust_%s.jpg' % (directory, illust.id), 'wb'))
+            api.download(
+                image_url,
+                path="/foo/bar",
+                fname=open("%s/illust_%s.jpg" % (directory, illust.id), "wb"),
+            )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/example_bypass_sni.py
+++ b/example_bypass_sni.py
@@ -1,15 +1,12 @@
 # -*- coding: utf-8 -*-
 
+import imp
 import sys
 from datetime import datetime, timedelta
-from pixivpy3 import *
 
-if sys.version_info >= (3, 0):
-    import imp
-    imp.reload(sys)
-else:
-    reload(sys)
-    sys.setdefaultencoding('utf8')
+from pixivpy3 import ByPassSniApi
+
+imp.reload(sys)
 sys.dont_write_bytecode = True
 
 
@@ -22,17 +19,27 @@ def main():
     api = ByPassSniApi()  # Same as AppPixivAPI, but bypass the GFW
     api.require_appapi_hosts()
     # api.set_additional_headers({'Accept-Language':'en-US'})
-    api.set_accept_language('en-us')
+    api.set_accept_language("en-us")
 
     # api.login(_USERNAME, _PASSWORD)
     print(api.auth(refresh_token=_REFRESH_TOKEN))
-    json_result = api.illust_ranking('day', date=(datetime.now() - timedelta(days=5)).strftime('%Y-%m-%d'))
+    json_result = api.illust_ranking(
+        "day", date=(datetime.now() - timedelta(days=5)).strftime("%Y-%m-%d")
+    )
 
-    print('Printing image titles and tags with English tag translations present when available')
+    print(
+        "Printing image titles and tags with English tag translations present when available"
+    )
 
     for illust in json_result.illusts[:3]:
-        print('Illustration: "' + str(illust.title) + '"\nTags: ' + str(illust.tags) + '\n')
+        print(
+            'Illustration: "'
+            + str(illust.title)
+            + '"\nTags: '
+            + str(illust.tags)
+            + "\n"
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/example_tag_translations.py
+++ b/example_tag_translations.py
@@ -1,16 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from datetime import *
-from pixivpy3 import *
+import imp
 import sys
+from datetime import datetime, timedelta
 
-if sys.version_info >= (3, 0):
-    import imp
-    imp.reload(sys)
-else:
-    reload(sys)
-    sys.setdefaultencoding('utf8')
+from pixivpy3 import AppPixivAPI
+
+imp.reload(sys)
 sys.dont_write_bytecode = True
 
 
@@ -22,16 +19,26 @@ _REFRESH_TOKEN = "0zeYA-PllRYp1tfrsq_w3vHGU1rPy237JMf5oDt73c4"
 def main():
     aapi = AppPixivAPI()
     # aapi.set_additional_headers({'Accept-Language':'en-US'})
-    aapi.set_accept_language('en-us')  # zh-cn
+    aapi.set_accept_language("en-us")  # zh-cn
 
     aapi.auth(refresh_token=_REFRESH_TOKEN)
-    json_result = aapi.illust_ranking('day', date=(datetime.now() - timedelta(days=5)).strftime('%Y-%m-%d'))
+    json_result = aapi.illust_ranking(
+        "day", date=(datetime.now() - timedelta(days=5)).strftime("%Y-%m-%d")
+    )
 
-    print('Printing image titles and tags with English tag translations present when available')
+    print(
+        "Printing image titles and tags with English tag translations present when available"
+    )
 
     for illust in json_result.illusts[:3]:
-        print('Illustration: "' + str(illust.title) + '"\nTags: ' + str(illust.tags) + '\n')
+        print(
+            'Illustration: "'
+            + str(illust.title)
+            + '"\nTags: '
+            + str(illust.tags)
+            + "\n"
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/pixivpy3/__init__.py
+++ b/pixivpy3/__init__.py
@@ -1,10 +1,10 @@
 """
 Pixiv API library
 """
-__version__ = '3.7.0'
+__version__ = "3.7.0"
 
 from .aapi import AppPixivAPI
 from .bapi import ByPassSniApi
 from .utils import PixivError
 
-__all__ = ('AppPixivAPI', 'ByPassSniApi', 'PixivError')
+__all__ = ("AppPixivAPI", "ByPassSniApi", "PixivError")

--- a/pixivpy3/aapi.py
+++ b/pixivpy3/aapi.py
@@ -1,22 +1,12 @@
 # -*- coding:utf-8 -*-
 
-import re
-import sys
-
-from .api import BasePixivAPI  # nopep8
-from .utils import PixivError  # nopep8
-
-if sys.version_info >= (3, 0):
-    import urllib.parse as up
-else:
-    import urlparse as up
-
-if sys.version_info >= (3, 7):
-    from typing import Any, Dict, List, Optional, Union
-
-    from .utils import ParsedJson, ParamDict, Response  # nopep8
+import urllib.parse as up
+from typing import Any, Dict, List, Optional, Union
 
 from requests.structures import CaseInsensitiveDict
+
+from .api import BasePixivAPI
+from .utils import ParamDict, ParsedJson, PixivError, Response
 
 
 # App-API (6.x - app-api.pixiv.net)
@@ -83,33 +73,13 @@ class AppPixivAPI(BasePixivAPI):
         result_qs = {}  # type: Dict[str, Union[str, List[str]]]
         query = up.urlparse(next_url).query
 
-        if sys.version_info >= (3, 0):
-            for key, value in up.parse_qs(query).items():
-                # merge seed_illust_ids[] liked PHP params to array
-                if "[" in key and key.endswith("]"):
-                    # keep the origin sequence, just ignore array length
-                    result_qs[key.split("[")[0]] = value
-                else:
-                    result_qs[key] = value[-1]
-
-        else:
-            # Python2 unquote may return utf8 instead of unicode
-            def safe_unquote(s):
-                return up.unquote(s.encode("utf8")).decode("utf8")
-
-            for kv in query.split("&"):
-                # split than unquote() to k,v strings
-                k, v = map(safe_unquote, kv.split("="))
-
-                # merge seed_illust_ids[] liked PHP params to array
-                matched = re.match("(?P<key>[\w]*)\[(?P<idx>[\w]*)\]", k)
-                if matched:
-                    mk = matched.group("key")
-                    marray = result_qs.get(mk, [])
-                    # keep the origin sequence, just ignore group('idx')
-                    result_qs[mk] = marray + [v]
-                else:
-                    result_qs[k] = v
+        for key, value in up.parse_qs(query).items():
+            # merge seed_illust_ids[] liked PHP params to array
+            if "[" in key and key.endswith("]"):
+                # keep the origin sequence, just ignore array length
+                result_qs[key.split("[")[0]] = value
+            else:
+                result_qs[key] = value[-1]
 
         return result_qs
 

--- a/pixivpy3/api.py
+++ b/pixivpy3/api.py
@@ -3,18 +3,13 @@ import hashlib
 import json
 import os
 import shutil
-import sys
 from datetime import datetime
+from typing import IO, Any, Optional, Union
 
 import cloudscraper  # type: ignore[import]
 from requests.structures import CaseInsensitiveDict
 
-from .utils import JsonDict, PixivError
-
-if sys.version_info >= (3, 7):
-    from typing import IO, Any, Optional, Union
-
-    from .utils import ParamDict, ParsedJson, Response
+from .utils import JsonDict, ParamDict, ParsedJson, PixivError, Response
 
 
 class BasePixivAPI(object):

--- a/pixivpy3/bapi.py
+++ b/pixivpy3/bapi.py
@@ -1,14 +1,11 @@
 # -*- coding:utf-8 -*-
 
-import sys
+from typing import Any, Union
 
 import requests
 from requests_toolbelt.adapters import host_header_ssl  # type: ignore[import]
 
 from .aapi import AppPixivAPI
-
-if sys.version_info >= (3, 7):
-    from typing import Any, Union
 
 
 class ByPassSniApi(AppPixivAPI):

--- a/pixivpy3/utils.py
+++ b/pixivpy3/utils.py
@@ -1,15 +1,12 @@
 # -*- coding:utf-8 -*-
 
-import sys
+from typing import Any, Dict, Optional, Union
 
-if sys.version_info >= (3, 7):
-    from typing import Any, Dict, Optional, Union
+from requests.structures import CaseInsensitiveDict
 
-    from requests.structures import CaseInsensitiveDict
-
-    ParamDict = Optional[Dict[str, Any]]
-    ParsedJson = Any
-    Response = Any
+ParamDict = Optional[Dict[str, Any]]
+ParsedJson = Any
+Response = Any
 
 
 class PixivError(Exception):

--- a/requirements.development.txt
+++ b/requirements.development.txt
@@ -1,5 +1,5 @@
-setuptools
-mypy
-flake8
-types-requests
+setuptools>=59.6.0
+mypy>=0.931
+flake8>=4.0.1
+types-requests>=2.27.10
 -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-requests>=2.0
+requests>=2.27.1
 requests_toolbelt>=0.9.1
-cloudscraper>=1.0,<1.2.50
+cloudscraper>=1.2.58

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,19 +21,18 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    requests>=2.0
+    requests>=2.27.1
     requests_toolbelt>=0.9.1
-    cloudscraper>=1.0,<1.2.50
+    cloudscraper>=1.2.58
 
-# python_requires = >= 3.7
-python_requires = >= 3.5
+python_requires = >= 3.6
 
 [options.extras_require]
 dev =
-    setuptools
-    mypy
-    flake8
-    types-requests
+    setuptools>=59.6.0
+    mypy>=0.931
+    flake8>=4.0.1
+    types-requests>=2.27.10
 
 [mypy]
 show_error_codes = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,8 @@ install_requires =
     requests_toolbelt>=0.9.1
     cloudscraper>=1.0,<1.2.50
 
-python_requires = >= 3.7
+# python_requires = >= 3.7
+python_requires = >= 3.5
 
 [options.extras_require]
 dev =

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ install_requires =
     requests_toolbelt>=0.9.1
     cloudscraper>=1.0,<1.2.50
 
-# python_requires = >= 3.7
+python_requires = >= 3.7
 
 [options.extras_require]
 dev =


### PR DESCRIPTION
[Vermin](https://github.com/netromdk/vermin) says:

```
File with incompatible versions: /Users/eggplants/prog/pixivpy/build/lib/pixivpy3/aapi.py
  'urllib.parse' module (requires !2, 3.0) vs. 'urlparse' module (requires 2.0, !3)
Note: Some files had incompatible versions so the results might not be correct!
Tip: You're using potentially backported modules: typing
If so, try using the following for better results: --backport typing

Tip: Since '# novm' or '# novermin' weren't used, a speedup can be achieved using: --no-parse-comments
Minimum required versions: 3.5
Incompatible versions:     2
```

I added version specifier for required python version and remove codes for python3.4 or older.
