### PR TITLE
Add literal types to params

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -4,34 +4,33 @@ on: [push, pull_request]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     strategy:
       max-parallel: 1
       fail-fast: false
       matrix:
-        python-version: ['3.6', '3.10']
+        python-version: ["3.8", "3.10"]
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.development.txt
-    - name: Lint with flake8
-      run: |
-        pip install flake8
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --ignore F821 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Run mypy
-      run: |
-        mypy
-    - name: Run demo.py
-      run: python demo.py
+      - uses: actions/checkout@v1
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.development.txt
+      - name: Lint with flake8
+        run: |
+          pip install flake8
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --ignore F821 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Run mypy
+        run: |
+          mypy
+      - name: Run demo.py
+        run: python demo.py

--- a/pixivpy3/aapi.py
+++ b/pixivpy3/aapi.py
@@ -1,13 +1,39 @@
 # -*- coding:utf-8 -*-
 
 import urllib.parse as up
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 
 from requests.structures import CaseInsensitiveDict
 from typeguard import typechecked
 
 from .api import BasePixivAPI
 from .utils import ParamDict, ParsedJson, PixivError, Response
+
+_FILTER = Literal["for_ios", ""]
+_TYPE = Literal["illust", "manga", ""]
+_RESTRICT = Literal["public", "private", ""]
+_CONTENT_TYPE = Literal["illust", "manga", ""]
+_MODE = Literal[
+    "day",
+    "week",
+    "month",
+    "day_male",
+    "day_female",
+    "week_original",
+    "week_rookie",
+    "day_manga",
+    "day_r18",
+    "day_male_r18",
+    "day_female_r18",
+    "week_r18",
+    "week_r18g",
+    "",
+]
+_SEARCH_TARGET = Literal[
+    "partial_match_for_tags", "exact_match_for_tags", "title_and_caption", ""
+]
+_SORT = Literal["date_desc", "date_asc", "popular_desc", ""]
+_DURATION = Literal["within_last_day", "within_last_week", "within_last_month", ""]
 
 
 # App-API (6.x - app-api.pixiv.net)

--- a/pixivpy3/aapi.py
+++ b/pixivpy3/aapi.py
@@ -33,7 +33,10 @@ _SEARCH_TARGET = Literal[
     "partial_match_for_tags", "exact_match_for_tags", "title_and_caption", ""
 ]
 _SORT = Literal["date_desc", "date_asc", "popular_desc", ""]
-_DURATION = Literal["within_last_day", "within_last_week", "within_last_month", ""]
+_DURATION = Literal[
+    "within_last_day", "within_last_week", "within_last_month", "", None
+]
+_BOOL = Literal["true", "false"]
 
 
 # App-API (6.x - app-api.pixiv.net)
@@ -84,7 +87,7 @@ class AppPixivAPI(BasePixivAPI):
             )
 
     @classmethod
-    def format_bool(cls, bool_value: Union[bool, str]) -> str:
+    def format_bool(cls, bool_value: Union[bool, str]) -> _BOOL:
         if isinstance(bool_value, bool):
             return "true" if bool_value else "false"
         if bool_value in {"true", "True"}:
@@ -113,7 +116,10 @@ class AppPixivAPI(BasePixivAPI):
 
     # 用户详情
     def user_detail(
-        self, user_id: Union[int, str], filter: str = "for_ios", req_auth: bool = True
+        self,
+        user_id: Union[int, str],
+        filter: _FILTER = "for_ios",
+        req_auth: bool = True,
     ) -> ParsedJson:
         url = "%s/v1/user/detail" % self.hosts
         params = {
@@ -128,8 +134,8 @@ class AppPixivAPI(BasePixivAPI):
     def user_illusts(
         self,
         user_id: Union[int, str],
-        type: str = "illust",
-        filter: str = "for_ios",
+        type: _TYPE = "illust",
+        filter: _FILTER = "for_ios",
         offset: Optional[Union[int, str]] = None,
         req_auth: bool = True,
     ) -> ParsedJson:
@@ -150,8 +156,8 @@ class AppPixivAPI(BasePixivAPI):
     def user_bookmarks_illust(
         self,
         user_id: Union[int, str],
-        restrict: str = "public",
-        filter: str = "for_ios",
+        restrict: _RESTRICT = "public",
+        filter: _FILTER = "for_ios",
         max_bookmark_id: Optional[Union[int, str]] = None,
         tag: Optional[str] = None,
         req_auth: bool = True,
@@ -172,7 +178,7 @@ class AppPixivAPI(BasePixivAPI):
     def user_related(
         self,
         seed_user_id: Union[int, str],
-        filter: str = "for_ios",
+        filter: _FILTER = "for_ios",
         offset: Optional[Union[int, str]] = None,
         req_auth: bool = True,
     ) -> ParsedJson:
@@ -190,7 +196,7 @@ class AppPixivAPI(BasePixivAPI):
     # restrict: [public, private]
     def illust_follow(
         self,
-        restrict: str = "public",
+        restrict: _RESTRICT = "public",
         offset: Optional[Union[int, str]] = None,
         req_auth: bool = True,
     ) -> ParsedJson:
@@ -237,7 +243,7 @@ class AppPixivAPI(BasePixivAPI):
     def illust_related(
         self,
         illust_id: Union[int, str],
-        filter: str = "for_ios",
+        filter: _FILTER = "for_ios",
         seed_illust_ids: Optional[Union[int, str]] = None,
         offset: Optional[Union[int, str]] = None,
         viewed: Optional[str] = None,
@@ -260,9 +266,9 @@ class AppPixivAPI(BasePixivAPI):
     # content_type: [illust, manga]
     def illust_recommended(
         self,
-        content_type: str = "illust",
+        content_type: _CONTENT_TYPE = "illust",
         include_ranking_label: bool = True,
-        filter: str = "for_ios",
+        filter: _FILTER = "for_ios",
         max_bookmark_id_for_recommend: Optional[Union[int, str]] = None,
         min_bookmark_id_for_recent_illust: Optional[Union[int, str]] = None,
         offset: Optional[Union[int, str]] = None,
@@ -315,8 +321,8 @@ class AppPixivAPI(BasePixivAPI):
     #               day_r18, day_male_r18, day_female_r18, week_r18, week_r18g]
     def illust_ranking(
         self,
-        mode: str = "day",
-        filter: str = "for_ios",
+        mode: _MODE = "day",
+        filter: _FILTER = "for_ios",
         date: Optional[str] = None,
         offset: Optional[Union[int, str]] = None,
         req_auth: bool = True,
@@ -335,7 +341,7 @@ class AppPixivAPI(BasePixivAPI):
 
     # 趋势标签 (Search - tags)
     def trending_tags_illust(
-        self, filter: str = "for_ios", req_auth: bool = True
+        self, filter: _FILTER = "for_ios", req_auth: bool = True
     ) -> ParsedJson:
         url = "%s/v1/trending-tags/illust" % self.hosts
         params = {
@@ -355,12 +361,12 @@ class AppPixivAPI(BasePixivAPI):
     def search_illust(
         self,
         word: str,
-        search_target: str = "partial_match_for_tags",
-        sort: str = "date_desc",
-        duration: Optional[str] = None,
+        search_target: _SEARCH_TARGET = "partial_match_for_tags",
+        sort: _SORT = "date_desc",
+        duration: _DURATION = None,
         start_date: Optional[str] = None,
         end_date: Optional[str] = None,
-        filter: Optional[str] = "for_ios",
+        filter: _FILTER = "for_ios",
         offset: Optional[Union[int, str]] = None,
         req_auth: bool = True,
     ) -> ParsedJson:
@@ -393,10 +399,10 @@ class AppPixivAPI(BasePixivAPI):
     def search_novel(
         self,
         word: str,
-        search_target: str = "partial_match_for_tags",
-        sort: str = "date_desc",
-        merge_plain_keyword_results: str = "true",
-        include_translated_tag_results: str = "true",
+        search_target: _SEARCH_TARGET = "partial_match_for_tags",
+        sort: _SORT = "date_desc",
+        merge_plain_keyword_results: _BOOL = "true",
+        include_translated_tag_results: _BOOL = "true",
         start_date: Optional[str] = None,
         end_date: Optional[str] = None,
         filter: Optional[str] = None,
@@ -424,9 +430,9 @@ class AppPixivAPI(BasePixivAPI):
     def search_user(
         self,
         word: str,
-        sort: str = "date_desc",
-        duration: Optional[str] = None,
-        filter: str = "for_ios",
+        sort: _SORT = "date_desc",
+        duration: _DURATION = None,
+        filter: _FILTER = "for_ios",
         offset: Optional[Union[int, str]] = None,
         req_auth: bool = True,
     ) -> ParsedJson:
@@ -458,7 +464,7 @@ class AppPixivAPI(BasePixivAPI):
     def illust_bookmark_add(
         self,
         illust_id: Union[int, str],
-        restrict: str = "public",
+        restrict: _RESTRICT = "public",
         tags: Optional[Union[str, List[str]]] = None,
         req_auth: bool = True,
     ) -> ParsedJson:
@@ -488,7 +494,10 @@ class AppPixivAPI(BasePixivAPI):
 
     # 关注用户
     def user_follow_add(
-        self, user_id: Union[int, str], restrict: str = "public", req_auth: bool = True
+        self,
+        user_id: Union[int, str],
+        restrict: _RESTRICT = "public",
+        req_auth: bool = True,
     ) -> ParsedJson:
         url = "%s/v1/user/follow/add" % self.hosts
         data = {"user_id": user_id, "restrict": restrict}
@@ -507,7 +516,7 @@ class AppPixivAPI(BasePixivAPI):
     # 用户收藏标签列表
     def user_bookmark_tags_illust(
         self,
-        restrict: str = "public",
+        restrict: _RESTRICT = "public",
         offset: Optional[Union[int, str]] = None,
         req_auth: bool = True,
     ) -> ParsedJson:
@@ -524,7 +533,7 @@ class AppPixivAPI(BasePixivAPI):
     def user_following(
         self,
         user_id: Union[int, str],
-        restrict: str = "public",
+        restrict: _RESTRICT = "public",
         offset: Optional[Union[int, str]] = None,
         req_auth: bool = True,
     ) -> ParsedJson:
@@ -543,7 +552,7 @@ class AppPixivAPI(BasePixivAPI):
     def user_follower(
         self,
         user_id: Union[int, str],
-        filter: str = "for_ios",
+        filter: _FILTER = "for_ios",
         offset: Optional[Union[int, str]] = None,
         req_auth: bool = True,
     ) -> ParsedJson:
@@ -579,7 +588,7 @@ class AppPixivAPI(BasePixivAPI):
     def user_list(
         self,
         user_id: Union[int, str],
-        filter: str = "for_ios",
+        filter: _FILTER = "for_ios",
         offset: Optional[Union[int, str]] = None,
         req_auth: bool = True,
     ) -> ParsedJson:
@@ -610,7 +619,7 @@ class AppPixivAPI(BasePixivAPI):
     def user_novels(
         self,
         user_id: Union[int, str],
-        filter: str = "for_ios",
+        filter: _FILTER = "for_ios",
         offset: Optional[Union[int, str]] = None,
         req_auth: bool = True,
     ) -> ParsedJson:
@@ -628,7 +637,7 @@ class AppPixivAPI(BasePixivAPI):
     def novel_series(
         self,
         series_id: Union[int, str],
-        filter: str = "for_ios",
+        filter: _FILTER = "for_ios",
         last_order: Optional[str] = None,
         req_auth: bool = True,
     ) -> ParsedJson:
@@ -670,8 +679,8 @@ class AppPixivAPI(BasePixivAPI):
     # content_type: [illust, manga]
     def illust_new(
         self,
-        content_type: str = "illust",
-        filter: str = "for_ios",
+        content_type: _CONTENT_TYPE = "illust",
+        filter: _FILTER = "for_ios",
         max_illust_id: Optional[Union[int, str]] = None,
         req_auth: bool = True,
     ) -> ParsedJson:

--- a/pixivpy3/aapi.py
+++ b/pixivpy3/aapi.py
@@ -4,6 +4,7 @@ import urllib.parse as up
 from typing import Any, Dict, List, Optional, Union
 
 from requests.structures import CaseInsensitiveDict
+from typeguard import typechecked
 
 from .api import BasePixivAPI
 from .utils import ParamDict, ParsedJson, PixivError, Response
@@ -11,6 +12,7 @@ from .utils import ParamDict, ParsedJson, PixivError, Response
 
 # App-API (6.x - app-api.pixiv.net)
 # noinspection PyShadowingBuiltins
+@typechecked
 class AppPixivAPI(BasePixivAPI):
     def __init__(self, **requests_kwargs: Any) -> None:
         """initialize requests kwargs if need be"""

--- a/pixivpy3/api.py
+++ b/pixivpy3/api.py
@@ -21,7 +21,7 @@ class BasePixivAPI(object):
 
     def __init__(self, **requests_kwargs: Any) -> None:
         """initialize requests kwargs if need be"""
-        self.user_id: int = 0
+        self.user_id: Union[int, str] = 0
         self.access_token: Optional[str] = None
         self.refresh_token: Optional[str] = None
         self.hosts = "https://app-api.pixiv.net"

--- a/pixivpy3/api.py
+++ b/pixivpy3/api.py
@@ -8,10 +8,12 @@ from typing import IO, Any, Optional, Union
 
 import cloudscraper  # type: ignore[import]
 from requests.structures import CaseInsensitiveDict
+from typeguard import typechecked
 
 from .utils import JsonDict, ParamDict, ParsedJson, PixivError, Response
 
 
+@typechecked
 class BasePixivAPI(object):
     client_id = "MOBrBDS8blbauoSck0ZfDbtuzpyT"
     client_secret = "lsACyCD94FhDUtGTXi3QzcFE2uU1hqtDaKeqrdwj"
@@ -19,7 +21,7 @@ class BasePixivAPI(object):
 
     def __init__(self, **requests_kwargs: Any) -> None:
         """initialize requests kwargs if need be"""
-        self.user_id = 0
+        self.user_id: int = 0
         self.access_token: Optional[str] = None
         self.refresh_token: Optional[str] = None
         self.hosts = "https://app-api.pixiv.net"

--- a/pixivpy3/bapi.py
+++ b/pixivpy3/bapi.py
@@ -4,10 +4,12 @@ from typing import Any, Union
 
 import requests
 from requests_toolbelt.adapters import host_header_ssl  # type: ignore[import]
+from typeguard import typechecked
 
 from .aapi import AppPixivAPI
 
 
+@typechecked
 class ByPassSniApi(AppPixivAPI):
     def __init__(self, **requests_kwargs: Any) -> None:
         """initialize requests kwargs if need be"""

--- a/pixivpy3/utils.py
+++ b/pixivpy3/utils.py
@@ -3,12 +3,14 @@
 from typing import Any, Dict, Optional, Union
 
 from requests.structures import CaseInsensitiveDict
+from typeguard import typechecked
 
 ParamDict = Optional[Dict[str, Any]]
 ParsedJson = Any
 Response = Any
 
 
+@typechecked
 class PixivError(Exception):
     """Pixiv API exception"""
 
@@ -28,6 +30,7 @@ class PixivError(Exception):
         return self.reason
 
 
+@typechecked
 class JsonDict(dict):  # type: ignore[type-arg]
     """general json object that allows attributes to be bound to and also behaves like a dict"""
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
     cloudscraper>=1.2.58
     typeguard>=2.13.3
 
-python_requires = >= 3.6
+python_requires = >= 3.8
 
 [options.extras_require]
 dev =

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ install_requires =
     requests>=2.27.1
     requests_toolbelt>=0.9.1
     cloudscraper>=1.2.58
+    typeguard>=2.13.3
 
 python_requires = >= 3.6
 


### PR DESCRIPTION
Close: #215 

Note: these changes require typing.Literal. This feature has been introduced in Python 3.8. So this branch has to manage in the experiment branch until 3.7 has reached EOL.

ref: https://github.com/upbit/pixivpy/issues/215#issuecomment-1053825311

