### PR TITLE
Add typed marker file (PEP 561)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,8 @@ install_requires =
     cloudscraper>=1.2.58
     typeguard>=2.13.3
     typing-extensions>=4.1.1
-
+package_data =
+    pixivpy3 = py.typed
 python_requires = >= 3.6
 
 [options.extras_require]


### PR DESCRIPTION
https://www.python.org/dev/peps/pep-0561/#id13

>In order to make packaging and distributing type information as simple and easy as possible, packaging and distribution is done through existing frameworks.
>
>Package maintainers who wish to support type checking of their code MUST add a marker file named py.typed to their package supporting typing. This marker applies recursively: if a top-level package includes it, all its sub-packages MUST support type checking as well. To have this file installed with the package, maintainers can use existing packaging options such as package_data in distutils, shown below.

To provide type information when distributing, `py.typed` is needed.