### PR TITLE
Fix a type for argument `next_url` of aapi.parse_qs

### DIFF
--- a/pixivpy3/aapi.py
+++ b/pixivpy3/aapi.py
@@ -111,8 +111,8 @@ class AppPixivAPI(BasePixivAPI):
 
     # 返回翻页用参数
     @classmethod
-    def parse_qs(cls, next_url: str) -> Optional[Dict[str, Union[str, List[str]]]]:
-        if not next_url:
+    def parse_qs(cls, next_url: Optional[str]) -> Optional[Dict[str, Union[str, List[str]]]]:
+        if next_url is None:
             return None
 
         result_qs: Dict[str, Union[str, List[str]]] = {}


### PR DESCRIPTION
Ref: https://github.com/upbit/pixivpy/runs/5404593738?check_suite_focus=true

I made a mistake of annotation of `next_url` in `aapi.parse_qs`.
