### PR TITLE
feat: Add more DoH servers

### DIFF
--- a/pixivpy3/bapi.py
+++ b/pixivpy3/bapi.py
@@ -22,14 +22,15 @@ class ByPassSniApi(AppPixivAPI):
         self, hostname: str = "app-api.pixiv.net", timeout: int = 3
     ) -> Union[str, bool]:
         """
-        通过 Cloudflare 的 DNS over HTTPS 请求真实的 IP 地址。
+        通过 DNS over HTTPS 服务获取真实 IP 地址。
         """
         URLS = (
             "https://1.0.0.1/dns-query",
-            "https://1.1.1.1/dns-query",
-            "https://[2606:4700:4700::1001]/dns-query",
-            "https://[2606:4700:4700::1111]/dns-query",
+            "https://dns.alidns.com/dns-query",
+            "https://doh.dns.sb/dns-query",
+            "https://doh.opendns.com/dns-query",
             "https://cloudflare-dns.com/dns-query",
+            "https://dns.google/dns-query"
         )
         params = {
             "ct": "application/dns-json",

--- a/pixivpy3/bapi.py
+++ b/pixivpy3/bapi.py
@@ -30,7 +30,7 @@ class ByPassSniApi(AppPixivAPI):
             "https://doh.dns.sb/dns-query",
             "https://doh.opendns.com/dns-query",
             "https://cloudflare-dns.com/dns-query",
-            "https://dns.google/dns-query"
+            "https://dns.google/dns-query",
         )
         params = {
             "ct": "application/dns-json",


### PR DESCRIPTION
#### Add more DoH servers
Currently, only Cloudflare's DoH service is used. Most of the user scenarios that need to get the real IP through DoH services are in China. But sometimes the Chinese network connection to Cloudflare's DoH service is not stable.

Therefore, the following service providers are used to enhance the stability of the Bypass API usage.

- https://1.0.0.1/dns-query
- https://dns.alidns.com/dns-query
- https://doh.dns.sb/dns-query
- https://doh.opendns.com/dns-query
- https://cloudflare-dns.com/dns-query
- https://dns.google/dns-query

These addresses work well in my project PixivBiu. The last three addresses are for redundancy reasons. Usually they won't be used.