### PR TITLE
Drop Python 3.6 and fix some

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -10,7 +10,8 @@ jobs:
       max-parallel: 1
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.10"]
+        # python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.10"]
 
     steps:
       - uses: actions/checkout@v1
@@ -21,10 +22,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.development.txt
+          pip install '.[dev]'
       - name: Lint with flake8
         run: |
-          pip install flake8
           # stop the build if there are Python syntax errors or undefined names
           flake8 . --count --select=E9,F63,F7,F82 --ignore F821 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide

--- a/pixivpy3/__init__.py
+++ b/pixivpy3/__init__.py
@@ -1,10 +1,10 @@
 """
 Pixiv API library
 """
-__version__ = "3.7.0"
 
 from .aapi import AppPixivAPI
 from .bapi import ByPassSniApi
 from .utils import PixivError
 
+__version__ = "3.7.0"
 __all__ = ("AppPixivAPI", "ByPassSniApi", "PixivError")

--- a/requirements.development.txt
+++ b/requirements.development.txt
@@ -1,8 +1,0 @@
-setuptools>=59.6.0
-mypy>=0.931
-flake8>=4.0.1
-types-requests>=2.27.10
-flake8-black>=0.3.0
-black[jupyter]>=22.1.0
-isort>=5.10.1
--r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-requests>=2.27.1
-requests_toolbelt>=0.9.1
-cloudscraper>=1.2.58
-typeguard>=2.13.3
-typing-extensions>=4.1.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,19 +20,20 @@ classifiers =
 
 [options]
 packages = find:
+python_requires = >= 3.7
 install_requires =
     requests>=2.27.1
     requests_toolbelt>=0.9.1
     cloudscraper>=1.2.58
     typeguard>=2.13.3
     typing-extensions>=4.1.1
-package_data =
-    pixivpy3 = py.typed
-python_requires = >= 3.6
+
+[options.package_data]
+pixivpy3 = py.typed
 
 [options.extras_require]
 dev =
-    setuptools>=59.6.0
+    setuptools>=60.9.3
     mypy>=0.931
     flake8>=4.0.1
     types-requests>=2.27.10

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,3 @@
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
+from setuptools import setup
 
 setup()


### PR DESCRIPTION
Python 3.6 executes `__init__.py` before installing dependencies when `pip install .` and it often raises `ModuleNotFoundError`.

Ref: https://github.com/pypa/setuptools/issues/1724

So I dropped Python 3.6. I have also made some changes accordingly, including the removal of requirements.txt and the non-use of distutils.
