### PR TITLE
Fix Cloudflare DoH API formats and add more servers

### DIFF
--- a/pixivpy3/bapi.py
+++ b/pixivpy3/bapi.py
@@ -22,13 +22,12 @@ class ByPassSniApi(AppPixivAPI):
         self, hostname: str = "app-api.pixiv.net", timeout: int = 3
     ) -> Union[str, bool]:
         """
-        通过 Cloudflare 的 DNS over HTTPS 请求真实的 IP 地址。
+        通过 DoH 服务请求真实的 IP 地址。
         """
         URLS = (
             "https://1.0.0.1/dns-query",
             "https://1.1.1.1/dns-query",
-            "https://[2606:4700:4700::1001]/dns-query",
-            "https://[2606:4700:4700::1111]/dns-query",
+            "https://doh.dns.sb/dns-query",
             "https://cloudflare-dns.com/dns-query",
         )
         headers = {"Accept": "application/dns-json"}

--- a/pixivpy3/bapi.py
+++ b/pixivpy3/bapi.py
@@ -31,8 +31,8 @@ class ByPassSniApi(AppPixivAPI):
             "https://[2606:4700:4700::1111]/dns-query",
             "https://cloudflare-dns.com/dns-query",
         )
+        headers = {"Accept": "application/dns-json"}
         params = {
-            "ct": "application/dns-json",
             "name": hostname,
             "type": "A",
             "do": "false",
@@ -41,7 +41,9 @@ class ByPassSniApi(AppPixivAPI):
 
         for url in URLS:
             try:
-                response = requests.get(url, params=params, timeout=timeout)
+                response = requests.get(
+                    url, headers=headers, params=params, timeout=timeout
+                )
                 self.hosts = "https://" + str(response.json()["Answer"][0]["data"])
                 return self.hosts
             except Exception:


### PR DESCRIPTION
#### 修复 Cloudflare DoH 服务 API 请求格式
Cloudflare 更改了 DoH 请求格式，因此目前 pixivpy 的 bypass 功能失效。

最新版中，若要返回 JSON 格式，需将 `application/dns-json` 声明至请求头的 `Accept` 中。

- https://developers.cloudflare.com/1.1.1.1/encryption/dns-over-https/make-api-requests/dns-json/

> JSON formatted queries are sent using a GET request. When making requests using GET, the DNS query is encoded into the URL. The client should include an HTTP Accept request header field with a MIME type of application/dns-json to indicate that the client is able to accept a JSON response from the DNS over HTTPS resolver.

#### 添加更多 DoH 服务器
由于国内网络对 Cloudflare DoH 服务的时稳时坏，因此添加 `https://doh.dns.sb/dns-query`，目前我个人使用下来较为稳定。

由于 IPv6 地址使用率不高且经常无法正常访问，故将其去除。

目前所使用的四个地址如下。

- https://1.0.0.1/dns-query
- https://1.1.1.1/dns-query
- https://doh.dns.sb/dns-query
- https://cloudflare-dns.com/dns-query

请求参数即为代码中所示，测试结果如下。

```
https://1.0.0.1/dns-query
{"Status":0,"TC":false,"RD":true,"RA":true,"AD":false,"CD":false,"Question":[{"name":"public-api.secure.pixiv.net","type":1}],"Answer":[{"name":"public-api.secure.pixiv.net","type":1,"TTL":240,"data":"210.140.92.186"},{"name":"public-api.secure.pixiv.net","type":1,"TTL":240,"data":"210.140.92.180"},{"name":"public-api.secure.pixiv.net","type":1,"TTL":240,"data":"210.140.92.183"}]}
https://1.1.1.1/dns-query
{"Status":0,"TC":false,"RD":true,"RA":true,"AD":false,"CD":false,"Question":[{"name":"public-api.secure.pixiv.net","type":1}],"Answer":[{"name":"public-api.secure.pixiv.net","type":1,"TTL":240,"data":"210.140.92.186"},{"name":"public-api.secure.pixiv.net","type":1,"TTL":240,"data":"210.140.92.183"},{"name":"public-api.secure.pixiv.net","type":1,"TTL":240,"data":"210.140.92.180"}]}
https://doh.dns.sb/dns-query
{"Status":0,"TC":false,"RD":true,"RA":true,"AD":false,"CD":false,"Question":[{"name":"public-api.secure.pixiv.net.","type":1}],"Answer":[{"name":"public-api.secure.pixiv.net.","type":1,"TTL":219,"Expires":"Mon, 07 Mar 2022 16:08:59 UTC","data":"210.140.92.183"},{"name":"public-api.secure.pixiv.net.","type":1,"TTL":219,"Expires":"Mon, 07 Mar 2022 16:08:59 UTC","data":"210.140.92.186"},{"name":"public-api.secure.pixiv.net.","type":1,"TTL":219,"Expires":"Mon, 07 Mar 2022 16:08:59 UTC","data":"210.140.92.180"}]}
https://cloudflare-dns.com/dns-query
{"Status":0,"TC":false,"RD":true,"RA":true,"AD":false,"CD":false,"Question":[{"name":"public-api.secure.pixiv.net","type":1}],"Answer":[{"name":"public-api.secure.pixiv.net","type":1,"TTL":240,"data":"210.140.92.186"},{"name":"public-api.secure.pixiv.net","type":1,"TTL":240,"data":"210.140.92.180"},{"name":"public-api.secure.pixiv.net","type":1,"TTL":240,"data":"210.140.92.183"}]}
```