### PR TITLE
setup.cfg: move package data into options

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,9 +26,11 @@ install_requires =
     cloudscraper>=1.2.58
     typeguard>=2.13.3
     typing-extensions>=4.1.1
-package_data =
-    pixivpy3 = py.typed
 python_requires = >= 3.6
+include_package_data = True
+
+[options.package_data]
+pixivpy3 = py.typed
 
 [options.extras_require]
 dev =


### PR DESCRIPTION
With latest pip (22.0.4) and setuptools (60.10.0) on python3.9, I get an error when installing from source unless `package_data` is moved into the `options.package_data` config section in `setup.cfg` (see example file in https://setuptools.pypa.io/en/latest/userguide/declarative_config.html)

```
$ pip install -e .
Obtaining file:///Users/pmrowla/git/pixivpy
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [45 lines of output]
      ...
        File "/Users/pmrowla/.virtualenvs/pixivpy/lib/python3.9/site-packages/setuptools/command/build_py.py", line 214, in _get_platform_patterns
          spec.get('', []),
      AttributeError: 'str' object has no attribute 'get'
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed
```

