### PR TITLE
Fix the forgotten header for auth

### DIFF
--- a/pixivpy3/api.py
+++ b/pixivpy3/api.py
@@ -161,7 +161,7 @@ class BasePixivAPI(object):
         else:
             raise PixivError("[ERROR] auth() but no password or refresh_token is set.")
 
-        r = self.requests_call("POST", url, headers=headers, data=data)
+        r = self.requests_call("POST", url, headers=headers_, data=data)
         if r.status_code not in {200, 301, 302}:
             if data["grant_type"] == "password":
                 raise PixivError(


### PR DESCRIPTION
https://github.com/upbit/pixivpy/commit/407b97cb872be04f81fbdfa64473e841d2dca10e 把`auth`中`CaseInsensitiveDict`化的`headers`重命名为了`headers_`，但post时没有使用。
这导致需要host的`ByPassSniApi`无法工作。