### PR TITLE
Added novel_new() method to retrieve latest novels

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,8 @@ class AppPixivAPI(BasePixivAPI):
     # 大家的新作
     # content_type: [illust, manga]
     def illust_new(content_type="illust", max_illust_id=None):
+        
+    def novel_new(max_novel_id=None):
 
     # 特辑详情 (无需登录，调用Web API)
     def showcase_article(showcase_id):

--- a/pixivpy3/aapi.py
+++ b/pixivpy3/aapi.py
@@ -714,10 +714,10 @@ class AppPixivAPI(BasePixivAPI):
         return self.parse_result(r)
 
     def novel_new(
-            self,
-            filter: _FILTER = "for_ios",
-            max_novel_id: int | str | None = None,
-            req_auth: bool = True,
+        self,
+        filter: _FILTER = "for_ios",
+        max_novel_id: int | str | None = None,
+        req_auth: bool = True,
     ) -> ParsedJson:
         url = "%s/v1/novel/new" % self.hosts
         params: dict[str, Any] = {

--- a/pixivpy3/aapi.py
+++ b/pixivpy3/aapi.py
@@ -713,6 +713,21 @@ class AppPixivAPI(BasePixivAPI):
         r = self.no_auth_requests_call("GET", url, params=params, req_auth=req_auth)
         return self.parse_result(r)
 
+    def novel_new(
+            self,
+            filter: _FILTER = "for_ios",
+            max_novel_id: int | str | None = None,
+            req_auth: bool = True,
+    ) -> ParsedJson:
+        url = "%s/v1/novel/new" % self.hosts
+        params: dict[str, Any] = {
+            "filter": filter,
+        }
+        if max_novel_id:
+            params["max_novel_id"] = max_novel_id
+        r = self.no_auth_requests_call("GET", url, params=params, req_auth=req_auth)
+        return self.parse_result(r)
+
     # 小说正文
     def novel_text(self, novel_id: int | str, req_auth: bool = True) -> ParsedJson:
         url = "%s/v1/novel/text" % self.hosts


### PR DESCRIPTION
Hello! While using the tool, I noticed that the route to retrieve latest novels didn't seem to be implemented, so I've gone ahead and done it. 

Similar to `illust_new()`, this returns JSON in the same format, simply with a `novels` key instead of `illusts`, and uses `max_novel_id` instead of `max_illust_id`. The `content_type` parameter is removed as it's not needed here, and otherwise, the API routes function identically. 

A note for users is that the novels API seems to return R18(G) content much more readily than using `illusts_new()` does, so anyone using this would need to be aware of that - though this is mitigated somewhat by not returning the novel text and needing a separate call for that. Examining at the API routes and parameters in the latest Android version of the app, neither the novels nor illustrations routes seem to have a parameter to change this behaviour. The web version, on the Latest Illustrations page, appends an `r18=true|false` query parameter, but the app API seems to ignore this if added manually.

Thank you for the great tool! 