### PR TITLE
ops(github): fix `GitHub` workflow

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -27,10 +27,6 @@ jobs:
       - name: Lint with pre-commit
         uses: pre-commit/action@v3.0.1
       - name: Install dependencies
-        run: poetry install --without dev
-      - name: Run demo.py
-        run: poetry run python demo.py
-      - name: Install dependencies tests
         run: poetry install
       - name: Run tests
         run: poetry run pytest

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -2,8 +2,6 @@ name: pixivpy
 
 on:
   push:
-    branches:
-      - master
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -7,14 +7,14 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       max-parallel: 1
       fail-fast: false
       matrix:
         # python-version: ["3.7", "3.8", "3.9", "3.10"]
-        python-version: ["3.7.17", "3.12"]
+        python-version: ["3.7", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Lint with pre-commit
         uses: pre-commit/action@v3.0.1
       - name: Install dependencies
-        run: poetry install --no-dev
+        run: poetry install --without dev
       - name: Run demo.py
         run: poetry run python demo.py
       - name: Install dependencies tests

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -2,6 +2,8 @@ name: pixivpy
 
 on:
   push:
+    branches:
+      - master
   pull_request:
   workflow_dispatch:
 
@@ -10,10 +12,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     strategy:
-      max-parallel: 1
-      fail-fast: false
       matrix:
-        # python-version: ["3.7", "3.8", "3.9", "3.10"]
         python-version: ["3.7", "3.12"]
 
     steps:

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         # python-version: ["3.7", "3.8", "3.9", "3.10"]
-        python-version: ["3.7", "3.12"]
+        python-version: ["3.7.17", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # PixivPy3 ![Build Status](https://github.com/upbit/pixivpy/workflows/pixivpy/badge.svg?branch=master) [![PyPI version](https://badge.fury.io/py/PixivPy3.svg)](https://badge.fury.io/py/PixivPy3)
 
-> Due to [#158](https://github.com/upbit/pixivpy/issues/158) reason, password login
-> no longer exist. Please use `api.auth(refresh_token=REFRESH_TOKEN)` instead
+> Due to [#158](https://github.com/upbit/pixivpy/issues/158) reason, password
+> login no longer exist. Please use `api.auth(refresh_token=REFRESH_TOKEN)`
+> instead.
 >
 > To get `refresh_token`, see
 > [@ZipFile Pixiv OAuth Flow](https://gist.github.com/ZipFile/c9ebedb224406f4f11845ab700124362)


### PR DESCRIPTION
### What this PR does?
Now the workflow works successfully.

### What's changed in details:
- Fix `README.md`, since it failed lint rules;
- Pin workflow Ubuntu version to `ubuntu-22.04`, since `ubuntu-24.04` does not support python3.7 ([src](https://github.com/actions/runner-images/issues/10636));
- Remove running `demo` from workflow, since the toke is required;

### You can see that the workflow now passes here:
https://github.com/Danipulok/pixivpy/actions/runs/12727727257